### PR TITLE
Implement shared job queue for Shopify order adjustments

### DIFF
--- a/src/routes/shopify.webhooks.js
+++ b/src/routes/shopify.webhooks.js
@@ -5,15 +5,12 @@ const fs = require('fs');
 const path = require('path');
 const { getInventoryItemSku } = require('../services/shopify.client');
 const { resolveSkuToItem } = require('../services/sku-map');
+const { enqueue } = require('../services/jobQueue');
 
 const router = express.Router();
 
 // === cola (mismo archivo que usa el server) ===
-const TMP_DIR = '/tmp';
-const QUEUE_PATH = path.join(TMP_DIR, 'jobs-queue.json');
-function readJobs() { try { return JSON.parse(fs.readFileSync(QUEUE_PATH, 'utf8')) || []; } catch { return []; } }
-function writeJobs(a){ fs.writeFileSync(QUEUE_PATH, JSON.stringify(a||[], null, 2), 'utf8'); }
-function enqueue(job) { const q=readJobs(); q.push(job); writeJobs(q); return q.length; }
+const TMP_DIR = process.env.LOG_DIR || '/tmp';
 
 // === snapshot de QBD para conocer QOH (QuantityOnHand)
 const INV_PATH = path.join(TMP_DIR, 'last-inventory.json');

--- a/src/services/jobQueue.js
+++ b/src/services/jobQueue.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_LOG_DIR = '/tmp';
+const DEFAULT_QUEUE_FILE = 'jobs.json';
+
+function resolveLogDir() {
+  const dir = (process.env.LOG_DIR || DEFAULT_LOG_DIR).trim() || DEFAULT_LOG_DIR;
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function queueFilePath() {
+  return path.join(resolveLogDir(), DEFAULT_QUEUE_FILE);
+}
+
+function readJobs() {
+  try {
+    const raw = fs.readFileSync(queueFilePath(), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    return [];
+  }
+}
+
+function writeJobs(list) {
+  const payload = Array.isArray(list) ? list : [];
+  fs.writeFileSync(queueFilePath(), JSON.stringify(payload, null, 2), 'utf8');
+  return payload;
+}
+
+function enqueue(job) {
+  if (!job || typeof job !== 'object') return readJobs();
+  const jobs = readJobs();
+  jobs.push(job);
+  writeJobs(jobs);
+  return jobs.length;
+}
+
+function peekJob() {
+  const jobs = readJobs();
+  return jobs.length > 0 ? jobs[0] : null;
+}
+
+function popJob() {
+  const jobs = readJobs();
+  if (jobs.length === 0) return null;
+  const job = jobs.shift();
+  writeJobs(jobs);
+  return job;
+}
+
+module.exports = {
+  queueFilePath,
+  readJobs,
+  writeJobs,
+  enqueue,
+  peekJob,
+  popJob,
+};


### PR DESCRIPTION
## Summary
- add a reusable job queue helper that persists in the same location as the web connector
- update the SOAP server to reuse the shared queue and generate inventory adjustment QBXML
- reuse the shared queue from the Shopify webhooks so orders enqueue QuickBooks adjustment jobs

## Testing
- node -e "const q=require('./src/services/jobQueue'); console.log('queue-length', q.readJobs().length);"
- node -e "require('./src/routes/shopify.webhooks'); console.log('webhooks ok');"

------
https://chatgpt.com/codex/tasks/task_e_68ca36bcbd28832ca6a4f4882bb424da