### PR TITLE
Ensure Shopify adjustments use full inventory snapshot

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,9 +283,10 @@ app.post(BASE_PATH, (req,res)=>{
         if (current && current.type === 'inventoryQuery') {
           const parsedItems = parseInventorySnapshot(resp);
           const { filtered: todaysItems, start, end } = filterInventoryForToday(parsedItems);
+          const generatedAt = new Date().toISOString();
           const snapshotPayload = {
             count: todaysItems.length,
-            filteredAt: new Date().toISOString(),
+            filteredAt: generatedAt,
             filter: {
               mode: 'TimeModifiedSameDay',
               timezoneOffsetMinutes: new Date().getTimezoneOffset(),
@@ -294,6 +295,8 @@ app.post(BASE_PATH, (req,res)=>{
               sourceCount: parsedItems.length,
             },
             items: todaysItems,
+            sourceGeneratedAt: generatedAt,
+            sourceItems: parsedItems,
           };
 
           save('last-inventory.json', JSON.stringify(snapshotPayload, null, 2));


### PR DESCRIPTION
## Summary
- persist the full QuickBooks inventory list in the snapshot saved during QBWC runs
- update Shopify webhook processing to fall back to the full snapshot when matching SKUs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca3f5f0f80832cb10652adadcec9bf