### PR TITLE
Integrate QBWC SOAP queue handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,13 @@
 'use strict';
 
+const http    = require('http');
 const express = require('express');
 const morgan  = require('morgan');
 const path    = require('path');
 const fs      = require('fs');
-const crypto  = require('crypto');
-const { buildInventoryQueryXML } = require('./services/inventory');
-const { buildInventoryAdjustmentXML } = require('./services/qbd.adjustment');
-const { readJobs, enqueue, peekJob, popJob } = require('./services/jobQueue');
-const { parseInventoryFromQBXML } = require('./services/inventoryParser');
-const { clearPendingByJobId, clearPendingBySkus } = require('./services/pendingAdjustments');
+const soap    = require('soap');
+const { readJobs, enqueue } = require('./services/jobQueue');
+const { qbwcServiceFactory } = require('./services/qbwcService');
 const { startAutoSync: startShopifyToQbdAutoSync } = require('./services/shopify.to.qbd');
 require('dotenv').config();
 
@@ -17,12 +15,9 @@ require('dotenv').config();
 const PORT      = process.env.PORT || 8080;             // En Azure Linux escucha 8080
 const BASE_PATH = process.env.BASE_PATH || '/qbwc';
 const LOG_DIR   = process.env.LOG_DIR || '/tmp';
-const TNS       = 'http://developer.intuit.com/';
-const CUR_JOB   = path.join(LOG_DIR, 'current-job.json');
 
 function ensureLogDir(){ try{ fs.mkdirSync(LOG_DIR,{recursive:true}); }catch{} }
 function fp(n){ return path.join(LOG_DIR,n); }
-function readText(f){ return fs.existsSync(f) ? fs.readFileSync(f,'utf8') : null; }
 function save(name, txt){ ensureLogDir(); fs.writeFileSync(fp(name), txt??'', 'utf8'); }
 function sendFileSmart(res, file){
   if(!fs.existsSync(file)) return res.status(404).send('not found');
@@ -31,87 +26,6 @@ function sendFileSmart(res, file){
   const looksJson = s.trim().startsWith('{')||s.trim().startsWith('[');
   res.type(looksXml?'application/xml':looksJson?'application/json':'text/plain').send(s);
 }
-function extract(text, tag){
-  const m = text.match(new RegExp(`<(?:\\w*:)?${tag}>([\\s\\S]*?)<\\/(?:\\w*:)?${tag}>`));
-  return m ? m[1] : '';
-}
-function extractCredsFromXml(xml){
-  const user = extract(xml, 'strUserName') || extract(xml, 'userName') || extract(xml, 'UserName');
-  const pass = extract(xml, 'strPassword') || extract(xml, 'password') || extract(xml, 'Password');
-  return { user, pass };
-}
-function envelope(body){
-  return `<?xml version="1.0" encoding="utf-8"?>`+
-         `<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">`+
-         `<soap:Body>${body}</soap:Body></soap:Envelope>`;
-}
-
-/* Generar QBXML según el job */
-function qbxmlFor(job) {
-  if (!job || !job.type) return '';
-
-  if (job.type === 'inventoryQuery') {
-    // Usamos el builder del servicio (desacople suave)
-    const hasExplicitMax =
-      Object.prototype.hasOwnProperty.call(job, 'max') && job.respectMax === true;
-    const requestedMax = hasExplicitMax ? Number(job.max) : NaN;
-    const max = Number.isFinite(requestedMax) && requestedMax > 0 ? Math.floor(requestedMax) : 0;
-    return buildInventoryQueryXML(max, process.env.QBXML_VER || '13.0');
-  }
-
-   if (job.type === 'inventoryAdjust') {
-    const ver = process.env.QBXML_VER || '16.0';
-    return buildInventoryAdjustmentXML(job.lines || [], job.account, ver);
-  }
-
-  // Mantén aquí tus otros tipos de job si los tienes
-  return '';
-}
-
-
-/* Parseo simple del ItemInventoryRet (sin libs) */
-function parseInventorySnapshot(qbxml){
-  try {
-    const parsed = parseInventoryFromQBXML(qbxml) || {};
-    return Array.isArray(parsed.items) ? parsed.items : [];
-  } catch (e) {
-    console.error('Inventory parse error:', e);
-    return [];
-  }
-}
-
-function shouldAutoPush(){
-  const raw = process.env.SHOPIFY_AUTO_PUSH;
-  if (raw == null || raw === '') return true;
-  return /^(1|true|yes)$/i.test(String(raw).trim());
-}
-
-function getTodayRange(now = new Date()){
-  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const end = new Date(start);
-  end.setDate(end.getDate() + 1);
-  return { start, end };
-}
-
-function parseQBDate(value){
-  if (!value) return null;
-  const dt = new Date(value);
-  return Number.isNaN(dt.valueOf()) ? null : dt;
-}
-
-function pickRelevantTimestamp(item){
-  return item?.TimeModified || item?.TimeCreated || null;
-}
-
-function filterInventoryForToday(items, now = new Date()){
-  const { start, end } = getTodayRange(now);
-  const filtered = (items || []).filter((item) => {
-    const stamp = parseQBDate(pickRelevantTimestamp(item));
-    return stamp && stamp >= start && stamp < end;
-  });
-  return { filtered, start, end };
-}
-
 /* ===== App ===== */
 const app = express();
 app.use(morgan(process.env.LOG_LEVEL || 'dev'));
@@ -150,6 +64,7 @@ app.get('/debug/last-auth-cred', (req,res)=>{
   res.type('application/json').send(fs.readFileSync(p,'utf8'));
 });
 app.get('/debug/last-response', (req, res) => sendFileSmart(res, fp('last-response.xml')));
+app.get('/debug/last-soap-response', (req, res) => sendFileSmart(res, fp('last-soap-response.xml')));
 
 /* Nueva cola: ver y sembrar */
 app.get('/debug/queue', (_req,res)=>res.json(readJobs()));
@@ -169,253 +84,28 @@ app.get('/debug/seed-inventory', (req,res)=>{
 app.get('/debug/inventory', (req,res)=>{
   sendFileSmart(res, fp('last-inventory.json'));
 });
-
-app.get('/qbwc', (req, res) => {
-  res.status(200).type('text/plain').send('QBWC endpoint OK');
-});
-
-
-/* WSDL (acepta ?wsdl aunque venga sin valor) */
-app.get(BASE_PATH, (req,res,next)=>{
-  if (!('wsdl' in req.query)) return next();
-  try{
-    const wsdlPath = path.join(__dirname,'wsdl','qbwc.wsdl');
-    const xml = fs.readFileSync(wsdlPath,'utf8');
-    res.type('application/xml').send(xml);
-  }catch(e){ res.status(500).send(String(e)); }
-});
-
-/* === Handler SOAP manual (todos los métodos mínimos) === */
-app.post(BASE_PATH, (req,res)=>{
-  let raw=''; req.setEncoding('utf8');
-  req.on('data', c=>{ raw+=c; });
-  req.on('end', ()=>{
-    try{
-      save('last-post-body.xml', raw);
-
-      const is = (tag)=> raw.includes(`<${tag}`) || raw.includes(`<tns:${tag}`);
-
-      let bodyXml = '';
-
-      if (is('serverVersion')) {
-        bodyXml = `<serverVersionResponse xmlns="${TNS}"><serverVersionResult>1.0.0-dev</serverVersionResult></serverVersionResponse>`;
-      }
-      else if (is('clientVersion')) {
-        bodyXml = `<clientVersionResponse xmlns="${TNS}"><clientVersionResult></clientVersionResult></clientVersionResponse>`;
-      }
-      else if (is('authenticate')) {
-        save('last-auth-request.xml', raw);
-        const {user,pass} = extractCredsFromXml(raw);
-        const envUser = process.env.WC_USERNAME || '';
-        const envPass = process.env.WC_PASSWORD || '';
-        const ok = (user===envUser && pass===envPass);
-
-        // justo después de calcular ok=true en authenticate:
-        if (ok && process.env.AUTO_SEED_ON_AUTH === 'true') {
-          enqueue({ type: 'inventoryQuery', ts: new Date().toISOString() });
-        }
-        if (process.env.AUTO_ENQUEUE_INVENTORY_QUERY === 'true') {
-          enqueue({ type: 'inventoryQuery', ts: new Date().toISOString() });
-        }
-
-
-
-        const passSha = crypto.createHash('sha256').update(pass||'', 'utf8').digest('hex');
-        const envSha  = crypto.createHash('sha256').update(envPass, 'utf8').digest('hex');
-        save('last-auth-cred.json', JSON.stringify({
-          ts:new Date().toISOString(),
-          receivedUser:user, receivedPassLen:(pass||'').length, receivedPassSha256:passSha,
-          envUser, envPassLen:envPass.length, envPassSha256:envSha,
-          matchUser:user===envUser, matchPassHash:passSha===envSha
-        },null,2));
-
-        // Ticket para esta sesión
-        const ticket = ok
-          ? (crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex'))
-          : '';
-
-        // ⬇️ Archivo de compañía:
-        //  - Si WC_COMPANY_FILE está vacío / no definido ⇒ ''  (usar el archivo YA ABIERTO en QuickBooks)
-        //  - Si prefieres forzar ruta, define WC_COMPANY_FILE con la ruta EXACTA en la VM.
-        let companyFile = '';
-        if (ok) {
-          const envPath = (process.env.WC_COMPANY_FILE || '').trim();
-          companyFile = envPath; // dejar '' para usar el archivo abierto
-        }
-        console.log('authenticate companyFile =>', companyFile || '(use currently open company)');
-
-        bodyXml =
-          `<authenticateResponse xmlns="${TNS}">` +
-            `<authenticateResult>` +
-              `<string>${ticket}</string>` +
-              `<string>${companyFile}</string>` +
-            `</authenticateResult>` +
-          `</authenticateResponse>`;
-
-        const envlp = envelope(bodyXml);
-        save('last-auth-response.xml', envlp);
-        res.type('text/xml').status(200).send(envlp);
-        return;
-
-      }
-      else if (is('sendRequestXML')) {
-        // ¿Hay trabajo en cola?
-        let job = peekJob();
-        if (job){
-          // Guardamos como "current" y lo sacamos de la cola
-          fs.writeFileSync(CUR_JOB, JSON.stringify(job));
-          popJob();
-          const qbxml = qbxmlFor(job);
-          save('last-request-qbxml.xml', qbxml);
-          bodyXml = `<sendRequestXMLResponse xmlns="${TNS}"><sendRequestXMLResult>${qbxml.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}</sendRequestXMLResult></sendRequestXMLResponse>`;
-        }else{
-          // Cola vacía -> retornar cadena vacía
-          bodyXml = `<sendRequestXMLResponse xmlns="${TNS}"><sendRequestXMLResult></sendRequestXMLResult></sendRequestXMLResponse>`;
-        }
-      }
-      else if (is('receiveResponseXML')) {
-        const resp = extract(raw, 'response');
-        const now  = Date.now();
-        save(`last-response-${now}.xml`, resp);
-        save('last-response.xml', resp);
-
-        // Leer job actual para decidir parseo
-        let current = null;
-        try{ current = JSON.parse(readText(CUR_JOB)||'null'); }catch{}
-        // Solo si el job fue de inventario, persistimos snapshot y (opcional) auto-push
-        if (current && current.type === 'inventoryQuery') {
-          const parsedItems = parseInventorySnapshot(resp);
-          const { filtered: todaysItems, start, end } = filterInventoryForToday(parsedItems);
-          const generatedAt = new Date().toISOString();
-          const snapshotPayload = {
-            count: todaysItems.length,
-            filteredAt: generatedAt,
-            filter: {
-              mode: 'TimeModifiedSameDay',
-              timezoneOffsetMinutes: new Date().getTimezoneOffset(),
-              start: start.toISOString(),
-              endExclusive: end.toISOString(),
-              sourceCount: parsedItems.length,
-            },
-            items: todaysItems,
-            sourceGeneratedAt: generatedAt,
-            sourceItems: parsedItems,
-          };
-
-          save('last-inventory.json', JSON.stringify(snapshotPayload, null, 2));
-          console.log('[inventory] snapshot filtered for today', {
-            totalReceived: parsedItems.length,
-            kept: todaysItems.length,
-            start: start.toISOString(),
-            end: end.toISOString(),
-          });
-
-          // --- Auto push a Shopify (después de persistir el snapshot) ---
-          try {
-            const m = resp.match(/<ItemInventoryQueryRs[^>]*statusCode="(\d+)"/i);
-            const ok = !m || m[1] === '0';
-            const auto = shouldAutoPush();
-
-            if (auto && !ok) {
-              console.warn('Auto-push skipped due to QuickBooks error status.');
-            }
-
-            if (auto && ok && todaysItems.length > 0) {
-              const { apply } = require('./services/shopify.sync');
-              setImmediate(() =>
-                apply().catch(e => console.error('Shopify apply error:', e))
-              );
-            } else if (auto && todaysItems.length === 0) {
-              console.log('Auto-push skipped: no inventory changes detected for today.');
-            }
-          } catch (e) {
-            console.error('Auto-push init error:', e);
-          }
-        }
-        else if (current && current.type === 'inventoryAdjust') {
-          try {
-            const match = resp.match(/<InventoryAdjustmentAddRs[^>]*statusCode="(\d+)"/i);
-            const status = match ? match[1] : null;
-            const ok = !match || status === '0';
-            if (ok) {
-              if (current.id) {
-                clearPendingByJobId(current.id);
-              } else if (Array.isArray(current.skus) && current.skus.length > 0) {
-                clearPendingBySkus(current.skus);
-              }
-              try {
-                const remaining = readJobs();
-                const hasRefreshQuery = remaining.some((job) => job && job.type === 'inventoryQuery');
-                if (!hasRefreshQuery) {
-                  enqueue({
-                    type: 'inventoryQuery',
-                    ts: new Date().toISOString(),
-                    source: 'shopify-adjust-refresh',
-                    triggeredBy: current.id || null,
-                  });
-                }
-              } catch (queueErr) {
-                console.error('inventoryAdjust refresh enqueue error:', queueErr);
-              }
-            } else {
-              console.warn('[inventoryAdjust] QuickBooks returned status', status, 'for job', current.id || '(no id)');
-            }
-          } catch (err) {
-            console.error('Pending Shopify adjustment cleanup error:', err);
-          }
-        }
-        // Limpio current job
-        try{ fs.unlinkSync(CUR_JOB); }catch{}
-
-        let progress = '100';
-        try {
-          const remainingJobs = readJobs();
-          if (Array.isArray(remainingJobs) && remainingJobs.length > 0) {
-            progress = '0';
-          }
-        } catch (err) {
-          console.error('queue progress check failed:', err);
-        }
-
-        bodyXml = `<receiveResponseXMLResponse xmlns="${TNS}"><receiveResponseXMLResult>${progress}</receiveResponseXMLResult></receiveResponseXMLResponse>`;
-      }
-      else if (is('getLastError')) {
-        bodyXml = `<getLastErrorResponse xmlns="${TNS}"><getLastErrorResult></getLastErrorResult></getLastErrorResponse>`;
-      }
-      else if (is('closeConnection')) {
-        bodyXml = `<closeConnectionResponse xmlns="${TNS}"><closeConnectionResult>OK</closeConnectionResult></closeConnectionResponse>`;
-      }
-      else if (is('connectionError')) {
-        const hresult = extract(raw, 'hresult') || '';
-        const message = extract(raw, 'message') || '';
-        console.error('WC connectionError:', hresult, message);
-        bodyXml = `<connectionErrorResponse xmlns="${TNS}"><connectionErrorResult>DONE</connectionErrorResult></connectionErrorResponse>`;
-      }
-
-      else {
-        const fault = `<?xml version="1.0" encoding="utf-8"?>
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-  <soap:Body>
-    <soap:Fault>
-      <faultcode>soap:Client</faultcode>
-      <faultstring>Method not implemented in stub</faultstring>
-    </soap:Fault>
-  </soap:Body>
-</soap:Envelope>`;
-        res.type('text/xml').status(200).send(fault);
-        return;
-      }
-
-      const envlp = envelope(bodyXml);
-      res.type('text/xml').status(200).send(envlp);
-    }catch(e){
-      res.status(500).type('text/plain').send(String(e));
-    }
-  });
-});
-
 /* Start */
-app.listen(PORT, ()=> console.log(`[QBWC] Listening http://localhost:${PORT}${BASE_PATH}`));
+const server = http.createServer(app);
+server.listen(PORT, ()=> console.log(`[QBWC] Listening http://localhost:${PORT}${BASE_PATH}`));
+
+try {
+  const wsdlPath = path.join(__dirname,'wsdl','qbwc.wsdl');
+  const wsdlXml = fs.readFileSync(wsdlPath,'utf8');
+  const soapService = qbwcServiceFactory();
+  const soapServer = soap.listen(server, BASE_PATH, soapService, wsdlXml);
+
+  soapServer.on('request', (requestXml) => {
+    try { save('last-post-body.xml', requestXml); }
+    catch (err) { console.error('[soap] failed to save last request:', err); }
+  });
+
+  soapServer.on('response', (responseXml) => {
+    try { save('last-soap-response.xml', responseXml); }
+    catch (err) { console.error('[soap] failed to save last SOAP response:', err); }
+  });
+} catch (err) {
+  console.error('[soap] init error:', err);
+}
 
 try {
   const auto = startShopifyToQbdAutoSync();

--- a/src/services/qbwc.queue.js
+++ b/src/services/qbwc.queue.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { buildInventoryQueryXML } = require('./inventory');
+const { buildInventoryAdjustmentXML } = require('./qbd.adjustment');
+const { parseInventoryFromQBXML } = require('./inventoryParser');
+const { readJobs, peekJob, popJob, enqueue } = require('./jobQueue');
+const { clearPendingByJobId, clearPendingBySkus } = require('./pendingAdjustments');
+
+const LOG_DIR = process.env.LOG_DIR || '/tmp';
+const CUR_JOB = path.join(LOG_DIR, 'current-job.json');
+const QBXML_VERSION_DEFAULT = process.env.QBXML_VER || '16.0';
+
+function ensureLogDir() {
+  try {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  } catch {
+    // ignore mkdir errors
+  }
+}
+
+function filePath(name) {
+  return path.join(LOG_DIR, name);
+}
+
+function save(name, text) {
+  ensureLogDir();
+  fs.writeFileSync(filePath(name), text ?? '', 'utf8');
+}
+
+function storeCurrentJob(job) {
+  if (!job) return;
+  ensureLogDir();
+  fs.writeFileSync(CUR_JOB, JSON.stringify(job, null, 2), 'utf8');
+}
+
+function loadCurrentJob() {
+  try {
+    const raw = fs.readFileSync(CUR_JOB, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function clearCurrentJob() {
+  try {
+    fs.unlinkSync(CUR_JOB);
+  } catch {
+    // ignore unlink errors
+  }
+}
+
+function qbxmlFor(job) {
+  if (!job || typeof job !== 'object') return '';
+
+  if (job.type === 'inventoryQuery') {
+    const hasExplicitMax = Object.prototype.hasOwnProperty.call(job, 'max') && job.respectMax === true;
+    const requestedMax = hasExplicitMax ? Number(job.max) : NaN;
+    const max = Number.isFinite(requestedMax) && requestedMax > 0 ? Math.floor(requestedMax) : 0;
+    return buildInventoryQueryXML(max, QBXML_VERSION_DEFAULT);
+  }
+
+  if (job.type === 'inventoryAdjust') {
+    const ver = QBXML_VERSION_DEFAULT || '16.0';
+    return buildInventoryAdjustmentXML(job.lines || [], job.account, ver);
+  }
+
+  if (job.type === 'raw-qbxml' && typeof job.qbxml === 'string') {
+    return job.qbxml;
+  }
+
+  return '';
+}
+
+function shouldAutoPush() {
+  const raw = process.env.SHOPIFY_AUTO_PUSH;
+  if (raw == null || raw === '') return true;
+  return /^(1|true|yes)$/i.test(String(raw).trim());
+}
+
+function getTodayRange(now = new Date()) {
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
+function parseQBDate(value) {
+  if (!value) return null;
+  const dt = new Date(value);
+  return Number.isNaN(dt.valueOf()) ? null : dt;
+}
+
+function pickRelevantTimestamp(item) {
+  return item?.TimeModified || item?.TimeCreated || null;
+}
+
+function filterInventoryForToday(items, now = new Date()) {
+  const { start, end } = getTodayRange(now);
+  const filtered = (items || []).filter((item) => {
+    const stamp = parseQBDate(pickRelevantTimestamp(item));
+    return stamp && stamp >= start && stamp < end;
+  });
+  return { filtered, start, end };
+}
+
+function parseInventorySnapshot(qbxml) {
+  try {
+    const parsed = parseInventoryFromQBXML(qbxml) || {};
+    return Array.isArray(parsed.items) ? parsed.items : [];
+  } catch (err) {
+    console.error('Inventory parse error:', err);
+    return [];
+  }
+}
+
+function prepareNextRequest() {
+  const job = peekJob();
+  if (!job) {
+    clearCurrentJob();
+    return { qbxml: '', job: null };
+  }
+
+  storeCurrentJob(job);
+  popJob();
+  const qbxml = qbxmlFor(job);
+
+  if (!qbxml) {
+    // no qbxml generated: skip job and move on
+    console.warn('[qbwc] No QBXML generated for job, skipping', job);
+    clearCurrentJob();
+    return prepareNextRequest();
+  }
+
+  save('last-request-qbxml.xml', qbxml);
+  return { qbxml, job };
+}
+
+function handleInventoryQueryResponse(resp) {
+  const parsedItems = parseInventorySnapshot(resp);
+  const { filtered: todaysItems, start, end } = filterInventoryForToday(parsedItems);
+  const generatedAt = new Date().toISOString();
+  const snapshotPayload = {
+    count: todaysItems.length,
+    filteredAt: generatedAt,
+    filter: {
+      mode: 'TimeModifiedSameDay',
+      timezoneOffsetMinutes: new Date().getTimezoneOffset(),
+      start: start.toISOString(),
+      endExclusive: end.toISOString(),
+      sourceCount: parsedItems.length,
+    },
+    items: todaysItems,
+    sourceGeneratedAt: generatedAt,
+    sourceItems: parsedItems,
+  };
+
+  save('last-inventory.json', JSON.stringify(snapshotPayload, null, 2));
+  console.log('[inventory] snapshot filtered for today', {
+    totalReceived: parsedItems.length,
+    kept: todaysItems.length,
+    start: start.toISOString(),
+    end: end.toISOString(),
+  });
+
+  try {
+    const statusMatch = resp.match(/<ItemInventoryQueryRs[^>]*statusCode="(\d+)"/i);
+    const ok = !statusMatch || statusMatch[1] === '0';
+    const auto = shouldAutoPush();
+
+    if (auto && !ok) {
+      console.warn('Auto-push skipped due to QuickBooks error status.');
+    }
+
+    if (auto && ok && todaysItems.length > 0) {
+      const { apply } = require('./shopify.sync');
+      setImmediate(() =>
+        apply().catch((e) => console.error('Shopify apply error:', e))
+      );
+    } else if (auto && todaysItems.length === 0) {
+      console.log('Auto-push skipped: no inventory changes detected for today.');
+    }
+  } catch (err) {
+    console.error('Auto-push init error:', err);
+  }
+}
+
+function handleInventoryAdjustResponse(resp, currentJob) {
+  try {
+    const match = resp.match(/<InventoryAdjustmentAddRs[^>]*statusCode="(\d+)"/i);
+    const status = match ? match[1] : null;
+    const ok = !match || status === '0';
+
+    if (ok) {
+      if (currentJob?.id) {
+        clearPendingByJobId(currentJob.id);
+      } else if (Array.isArray(currentJob?.skus) && currentJob.skus.length > 0) {
+        clearPendingBySkus(currentJob.skus);
+      }
+
+      try {
+        const remaining = readJobs();
+        const hasRefreshQuery = remaining.some((job) => job && job.type === 'inventoryQuery');
+        if (!hasRefreshQuery) {
+          enqueue({
+            type: 'inventoryQuery',
+            ts: new Date().toISOString(),
+            source: 'shopify-adjust-refresh',
+            triggeredBy: currentJob?.id || null,
+          });
+        }
+      } catch (queueErr) {
+        console.error('inventoryAdjust refresh enqueue error:', queueErr);
+      }
+    } else {
+      console.warn('[inventoryAdjust] QuickBooks returned status', status, 'for job', currentJob?.id || '(no id)');
+    }
+  } catch (err) {
+    console.error('Pending Shopify adjustment cleanup error:', err);
+  }
+}
+
+function handleResponse(responseXml) {
+  const resp = responseXml || '';
+  const ts = Date.now();
+  save(`last-response-${ts}.xml`, resp);
+  save('last-response.xml', resp);
+
+  const current = loadCurrentJob();
+
+  if (current?.type === 'inventoryQuery') {
+    handleInventoryQueryResponse(resp);
+  } else if (current?.type === 'inventoryAdjust') {
+    handleInventoryAdjustResponse(resp, current);
+  }
+
+  clearCurrentJob();
+
+  let progress = 100;
+  try {
+    const remainingJobs = readJobs();
+    if (Array.isArray(remainingJobs) && remainingJobs.length > 0) {
+      progress = 0;
+    }
+  } catch (err) {
+    console.error('queue progress check failed:', err);
+  }
+
+  return progress;
+}
+
+module.exports = {
+  prepareNextRequest,
+  handleResponse,
+  qbxmlFor,
+};

--- a/src/services/qbwcService.js
+++ b/src/services/qbwcService.js
@@ -5,22 +5,20 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
+const { prepareNextRequest, handleResponse } = require('./qbwc.queue');
+const { enqueue } = require('./jobQueue');
+
 /**
  * OBJETIVO
  * - Mantener authenticate EXACTO (usuario/contraseña desde variables de entorno).
- * - Implementar sendRequestXML para que SIEMPRE devuelva un QBXML de inventario (pull bajo demanda en cada corrida).
- * - Implementar receiveResponseXML para parsear ItemInventory, ItemInventoryAssembly y (si aplica) ItemSites (Advanced Inventory).
+ * - Integrar QuickBooks Web Connector con la cola de trabajos (InventoryQuery/InventoryAdjust, etc.).
  * - Guardar archivos de depuración en /tmp para validar fácilmente desde tus endpoints actuales (/debug/*).
- *
- * No agrega dependencias y no requiere cambios en index.js ni en el WSDL.
  */
 
 /* =========================
    Configuración y helpers
    ========================= */
 const LOG_DIR = process.env.LOG_DIR || '/tmp';
-const HAS_ADV_INV = (process.env.HAS_ADV_INV || '').toString() === '1'; // 1 si tu QBD tiene Advanced Inventory
-const QB_MAX = Number(process.env.QB_MAX || 200) || 200;                // límite de ítems a pedir en cada tipo
 const TNS = 'http://developer.intuit.com/';
 
 const APP_USER = process.env.WC_USERNAME || '';
@@ -28,98 +26,7 @@ const APP_PASS = process.env.WC_PASSWORD || '';
 
 function ensureDir(p) { try { fs.mkdirSync(p, { recursive: true }); } catch { /* noop */ } }
 function save(name, txt) { ensureDir(LOG_DIR); fs.writeFileSync(path.join(LOG_DIR, name), txt ?? '', 'utf8'); }
-function read(name) { try { return fs.readFileSync(path.join(LOG_DIR, name), 'utf8'); } catch { return null; } }
 function sha256(s) { return crypto.createHash('sha256').update(s || '').digest('hex'); }
-
-/* =========================
-   Construcción de QBXML
-   ========================= */
-function buildInventoryQBXML(max = QB_MAX) {
-  const inv = `
-    <ItemInventoryQueryRq requestID="1">
-      <ActiveStatus>All</ActiveStatus>
-      <OwnerID>0</OwnerID>
-      <MaxReturned>${max}</MaxReturned>
-    </ItemInventoryQueryRq>`;
-
-  const asm = `
-    <ItemInventoryAssemblyQueryRq requestID="2">
-      <ActiveStatus>All</ActiveStatus>
-      <OwnerID>0</OwnerID>
-      <MaxReturned>${max}</MaxReturned>
-    </ItemInventoryAssemblyQueryRq>`;
-
-  const sites = HAS_ADV_INV ? `
-    <ItemSitesQueryRq requestID="3">
-      <ActiveStatus>All</ActiveStatus>
-      <OwnerID>0</OwnerID>
-      <MaxReturned>${max}</MaxReturned>
-    </ItemSitesQueryRq>` : '';
-
-  const qbxml = `<?xml version="1.0"?><?qbxml version="16.0"?>
-<QBXML>
-  <QBXMLMsgsRq onError="stopOnError">
-    ${inv}${asm}${sites}
-  </QBXMLMsgsRq>
-</QBXML>`;
-
-  save('last-request-qbxml.xml', qbxml);
-  return qbxml;
-}
-
-/* =========================
-   Parser simple (sin libs)
-   ========================= */
-// Matchea bloques <Tag> ... </Tag> incluso multi-línea
-function blocks(xml, tag) {
-  return xml.match(new RegExp(`<${tag}[\\s\\S]*?<\\/${tag}>`, 'g')) || [];
-}
-// Extrae el contenido de <tag>valor</tag>
-function val(block, tag) {
-  const m = block.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, 'i'));
-  return m ? m[1] : '';
-}
-
-function parseInventory(qbxml) {
-  const out = [];
-
-  // Ítems de inventario
-  for (const b of blocks(qbxml, 'ItemInventoryRet')) {
-    out.push({
-      Type: 'ItemInventoryRet',
-      ListID: val(b, 'ListID') || null,
-      FullName: val(b, 'FullName') || val(b, 'Name') || null,
-      QuantityOnHand: Number(val(b, 'QuantityOnHand') || 0),
-      EditSequence: val(b, 'EditSequence') || null
-    });
-  }
-
-  // Ensambles de inventario
-  for (const b of blocks(qbxml, 'ItemInventoryAssemblyRet')) {
-    out.push({
-      Type: 'ItemInventoryAssemblyRet',
-      ListID: val(b, 'ListID') || null,
-      FullName: val(b, 'FullName') || val(b, 'Name') || null,
-      QuantityOnHand: Number(val(b, 'QuantityOnHand') || 0),
-      EditSequence: val(b, 'EditSequence') || null
-    });
-  }
-
-  // Niveles por sitio (si hay Advanced Inventory)
-  for (const b of blocks(qbxml, 'ItemSitesRet')) {
-    const itemRef = (b.match(/<ItemInventoryRef>[\\s\\S]*?<\\/ItemInventoryRef>/i) || [null])[0]
-                 || (b.match(/<ItemRef>[\\s\\S]*?<\\/ItemRef>/i) || [null])[0] || '';
-    const siteRef = (b.match(/<SiteRef>[\\s\\S]*?<\\/SiteRef>/i) || [null])[0] || '';
-    out.push({
-      Type: 'ItemSitesRet',
-      ItemFullName: val(itemRef, 'FullName') || null,
-      SiteFullName: val(siteRef, 'FullName') || null,
-      QuantityOnHand: Number(val(b, 'QuantityOnHand') || 0)
-    });
-  }
-
-  return out;
-}
 
 /* =========================
    Servicio SOAP
@@ -161,6 +68,18 @@ function qbwcServiceFactory() {
       }
 
       const ticket = crypto.randomUUID();
+      if (user === APP_USER && pass === APP_PASS) {
+        try {
+          if (process.env.AUTO_SEED_ON_AUTH === 'true') {
+            enqueue({ type: 'inventoryQuery', ts: new Date().toISOString(), source: 'auth-auto-seed' });
+          }
+          if (process.env.AUTO_ENQUEUE_INVENTORY_QUERY === 'true') {
+            enqueue({ type: 'inventoryQuery', ts: new Date().toISOString(), source: 'auth-auto-enqueue' });
+          }
+        } catch (queueErr) {
+          console.error('[qbwc] auto enqueue on auth failed:', queueErr);
+        }
+      }
       // 'none' = usar el company file actualmente abierto en QBD
       save('last-auth-response.xml',
         `<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="${TNS}"><soap:Body><tns:authenticateResponse><authenticateResult><string>${ticket}</string><string>none</string></authenticateResult></tns:authenticateResponse></soap:Body></soap:Envelope>`);
@@ -168,28 +87,24 @@ function qbwcServiceFactory() {
     },
 
     /**
-     * Devuelve QBXML de inventario en cada corrida.
-     * (Si prefieres “bajo demanda”, aquí se podría leer un trigger/cola; por simplicidad, lo enviamos siempre).
+     * Devuelve el siguiente QBXML pendiente en la cola (o cadena vacía si no hay trabajo).
      */
     sendRequestXML(args, cb) {
-      const qbxml = buildInventoryQBXML(QB_MAX);
+      const { qbxml } = prepareNextRequest();
+      const payload = qbxml || '';
       // IMPORTANTE: node-soap se encarga del envelope, aquí solo devolver el QBXML
-      cb(null, { sendRequestXMLResult: qbxml });
+      cb(null, { sendRequestXMLResult: payload });
     },
 
     /**
-     * Recibe la respuesta QBXML, la guarda y la parsea a JSON consolidado en /tmp/last-inventory.json
+     * Recibe la respuesta QBXML, la guarda y delega en el manejador común para actualizar estados/logs.
      */
     receiveResponseXML(args, cb) {
       const xml = args?.response || args?.responseXml || args?.strResponseXML || '';
-      save(`last-response-${Date.now()}.xml`, xml);
-      save('last-response.xml', xml);
+      const progress = handleResponse(xml);
 
-      const items = parseInventory(xml);
-      save('last-inventory.json', JSON.stringify({ count: items.length, items }, null, 2));
-
-      // 100 = no hay más trabajo en esta sesión
-      cb(null, { receiveResponseXMLResult: 100 });
+      // 100 = no hay más trabajo en esta sesión (0 si aún quedan jobs)
+      cb(null, { receiveResponseXMLResult: progress });
     },
 
     getLastError(args, cb) {


### PR DESCRIPTION
## Summary
- replace the manual QuickBooks SOAP handler with a soap.js listener that exposes the qbXML queue and logs the last SOAP traffic for debugging
- add a dedicated queue runner that builds qbXML requests from queued jobs, persists responses, and keeps Shopify auto-push behaviour intact
- update the QBWC service to feed the queue-driven qbXML payloads, clear Shopify pending adjustments, and auto-enqueue refreshes after authenticate

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68cb048b75e8832cb2739af781ee54c8