### PR TITLE
Persist full QuickBooks inventory snapshot for webhook lookups

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -328,6 +328,7 @@ app.post(BASE_PATH, (req,res)=>{
               sourceCount: parsedItems.length,
             },
             items: todaysItems,
+            allItems: parsedItems,
           };
 
           save('last-inventory.json', JSON.stringify(snapshotPayload, null, 2));


### PR DESCRIPTION
## Summary
- persist the complete QuickBooks inventory list alongside the filtered items when saving the snapshot
- teach the Shopify webhooks loader to expose the full list and resolve SKUs against it for inventory and product updates

## Testing
- node <<'NODE' ... NODE


------
https://chatgpt.com/codex/tasks/task_e_68cd79a0c8b4832caaa5e3e22cc8c366