### PR TITLE
Sanitize inventory adjustment lines before building qbXML

### DIFF
--- a/src/services/qbd.adjustment.js
+++ b/src/services/qbd.adjustment.js
@@ -1,27 +1,53 @@
 // src/services/qbd.adjustment.js
+
 function esc(s) {
-  return String(s).replace(/[<>&'"]/g, (ch) => (
+  return String(s).replace(/[<>&'\"]/g, (ch) => (
     ch === '<' ? '&lt;' : ch === '>' ? '&gt;' : ch === '&' ? '&amp;' : ch === "'" ? '&apos;' : '&quot;'
   ));
 }
 
-function lineXml(l) {
-  const ref = l.ListID
-    ? `<ListID>${esc(l.ListID)}</ListID>`
-    : `<FullName>${esc(l.FullName)}</FullName>`;
-  const q = Number(l.QuantityDifference || 0);
+function normalizeLine(line) {
+  if (!line || typeof line !== 'object') return null;
+
+  const hasListId = line.ListID != null && line.ListID !== '';
+  const rawRef = hasListId ? line.ListID : line.FullName || line.Name;
+  if (!rawRef) return null;
+
+  const rawQty =
+    line.QuantityDifference ??
+    line.quantityDifference ??
+    line.Quantity ??
+    line.quantity ??
+    null;
+  const qty = Number(rawQty);
+  if (!Number.isFinite(qty) || qty === 0) return null;
+
+  const ref = hasListId
+    ? `<ListID>${esc(rawRef)}</ListID>`
+    : `<FullName>${esc(rawRef)}</FullName>`;
+
   return `
       <InventoryAdjustmentLineAdd>
         <ItemRef>${ref}</ItemRef>
         <QuantityAdjustment>
-          <QuantityDifference>${q}</QuantityDifference>
+          <QuantityDifference>${qty}</QuantityDifference>
         </QuantityAdjustment>
       </InventoryAdjustmentLineAdd>`;
 }
 
-function buildInventoryAdjustmentXML(lines = [], accountName, qbxmlVer = process.env.QBXML_VER || '16.0') {
+function buildInventoryAdjustmentXML(
+  lines = [],
+  accountName,
+  qbxmlVer = process.env.QBXML_VER || '16.0'
+) {
   const ver = String(qbxmlVer || '16.0');
   const account = accountName || process.env.QBD_ADJUST_ACCOUNT || 'Inventory Adjustment';
+  const validLines = (Array.isArray(lines) ? lines : [])
+    .map((line) => normalizeLine(line))
+    .filter(Boolean);
+
+  if (!validLines.length) return '';
+
   const header = `<?xml version="1.0" ?><?qbxml version="${ver}"?>\r\n`;
   const body = `
 <QBXML>
@@ -29,7 +55,7 @@ function buildInventoryAdjustmentXML(lines = [], accountName, qbxmlVer = process
     <InventoryAdjustmentAddRq requestID="adj-1">
       <InventoryAdjustmentAdd>
         <AccountRef><FullName>${esc(account)}</FullName></AccountRef>
-        ${lines.map(lineXml).join('')}
+        ${validLines.join('')}
       </InventoryAdjustmentAdd>
     </InventoryAdjustmentAddRq>
   </QBXMLMsgsRq>


### PR DESCRIPTION
## Summary
- validate inventory adjustment lines before generating qbXML so malformed payloads are skipped
- filter out lines without item references or numeric quantity differences and short-circuit empty payloads

## Testing
- node - <<'NODE'
const { buildInventoryAdjustmentXML } = require('./src/services/qbd.adjustment');
const base = { FullName: 'Sample Item', QuantityDifference: 3 };
console.log(buildInventoryAdjustmentXML([base]));
console.log('--- invalid line (NaN) ->', JSON.stringify(buildInventoryAdjustmentXML([{ FullName: 'Bad', QuantityDifference: 'abc' }])));
console.log('--- empty ->', JSON.stringify(buildInventoryAdjustmentXML([])));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d0558e50d0832c9f4ab333065568dd