### PR TITLE
Log qbXML before returning in sendRequestXML

### DIFF
--- a/src/services/qbwcService.js
+++ b/src/services/qbwcService.js
@@ -173,6 +173,7 @@ function qbwcServiceFactory() {
      */
     sendRequestXML(args, cb) {
       const qbxml = buildInventoryQBXML(QB_MAX);
+      console.log('[qbwcService] sendRequestXML qbXML:', qbxml);
       // IMPORTANTE: node-soap se encarga del envelope, aquí solo devolver el QBXML
       cb(null, { sendRequestXMLResult: qbxml });
     },


### PR DESCRIPTION
## Summary
- log the qbXML payload generated in sendRequestXML before returning it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0600d4e40832cbd688406dddb966a