### PR TITLE
Ensure qbXML logging is flushed in sendRequestXML

### DIFF
--- a/src/services/qbwcService.js
+++ b/src/services/qbwcService.js
@@ -173,6 +173,17 @@ function qbwcServiceFactory() {
      */
     sendRequestXML(args, cb) {
       const qbxml = buildInventoryQBXML(QB_MAX);
+      const stamp = new Date().toISOString();
+      const logBlock = [
+        `[${stamp}] [qbwcService] sendRequestXML qbXML BEGIN`,
+        qbxml,
+        `[${stamp}] [qbwcService] sendRequestXML qbXML END`
+      ].join('\n');
+      if (process.stdout && typeof process.stdout.write === 'function') {
+        process.stdout.write(`${logBlock}\n`);
+      } else {
+        console.log(logBlock);
+      }
       // IMPORTANTE: node-soap se encarga del envelope, aquí solo devolver el QBXML
       cb(null, { sendRequestXMLResult: qbxml });
     },


### PR DESCRIPTION
## Summary
- log the qbXML payload using a timestamped block and process.stdout to ensure the exact XML is visible before responding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0600d4e40832cbd688406dddb966a