### PR TITLE
Log receiveResponseXML qbXML payload

### DIFF
--- a/src/services/qbwcService.js
+++ b/src/services/qbwcService.js
@@ -193,6 +193,17 @@ function qbwcServiceFactory() {
      */
     receiveResponseXML(args, cb) {
       const xml = args?.response || args?.responseXml || args?.strResponseXML || '';
+      const stamp = new Date().toISOString();
+      const logBlock = [
+        `[${stamp}] [qbwcService] receiveResponseXML qbXML BEGIN`,
+        xml,
+        `[${stamp}] [qbwcService] receiveResponseXML qbXML END`
+      ].join('\n');
+      if (process.stdout && typeof process.stdout.write === 'function') {
+        process.stdout.write(`${logBlock}\n`);
+      } else {
+        console.log(logBlock);
+      }
       save(`last-response-${Date.now()}.xml`, xml);
       save('last-response.xml', xml);
 


### PR DESCRIPTION
## Summary
- add a timestamped log block around receiveResponseXML payloads mirroring sendRequestXML logging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d06f726cd4832c878d0f4ce0562ef4