### PR TITLE
Log QBXML payloads to stdout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -298,6 +298,7 @@ app.post(BASE_PATH, (req,res)=>{
           setCurrentJob(job);
           popJob();
           save('last-request-qbxml.xml', qbxml);
+          console.log('[qbwc] sendRequestXML QBXML payload:', qbxml);
           bodyXml = `<sendRequestXMLResponse xmlns="${TNS}"><sendRequestXMLResult>${qbxml.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}</sendRequestXMLResult></sendRequestXMLResponse>`;
         } else {
           // Cola vacía -> retornar cadena vacía
@@ -310,6 +311,7 @@ app.post(BASE_PATH, (req,res)=>{
         const now  = Date.now();
         save(`last-response-${now}.xml`, resp);
         save('last-response.xml', resp);
+        console.log('[qbwc] receiveResponseXML QBXML payload:', resp);
 
         // Leer job actual para decidir parseo
         const current = getCurrentJob();


### PR DESCRIPTION
## Summary
- log the QBXML payload generated in sendRequestXML immediately after writing the debug file
- log the QBXML payload received in receiveResponseXML after persisting the response copies

## Testing
- npm start
- curl -s -X POST http://localhost:8080/qbwc ...sendRequestXML payload...
- curl -s -X POST http://localhost:8080/qbwc ...receiveResponseXML payload...


------
https://chatgpt.com/codex/tasks/task_e_68d0a8485fd0832c9b2249b41ab76c49