### PR TITLE
Log QuickBooks response status codes from receiveResponseXML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const { buildInventoryAdjustmentXML } = require('./services/qbd.adjustment');
 const { buildSalesReceiptXML } = require('./services/qbd.salesReceipt');
 const { buildCreditMemoXML } = require('./services/qbd.creditMemo');
 const { buildItemInventoryModXML } = require('./services/qbd.itemMod');
+const { extractStatusSummaries } = require('./services/qbxml.status');
 const {
   readJobs,
   enqueueJob,
@@ -311,6 +312,10 @@ app.post(BASE_PATH, (req,res)=>{
         const now  = Date.now();
         save(`last-response-${now}.xml`, resp);
         save('last-response.xml', resp);
+        const statuses = extractStatusSummaries(resp);
+        if (statuses.length > 0) {
+          console.log('[qbwc] receiveResponseXML status summary:', statuses);
+        }
         //console.log('[qbwc] receiveResponseXML QBXML payload:', resp);
 
         // Leer job actual para decidir parseo

--- a/src/services/qbwcService.js
+++ b/src/services/qbwcService.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { extractStatusSummaries } = require('./qbxml.status');
 
 /**
  * OBJETIVO
@@ -203,6 +204,15 @@ function qbwcServiceFactory() {
         process.stdout.write(`${logBlock}\n`);
       } else {
         console.log(logBlock);
+      }
+      const statuses = extractStatusSummaries(xml);
+      if (statuses.length > 0) {
+        const statusLog = `[${stamp}] [qbwcService] receiveResponseXML status summary: ${JSON.stringify(statuses)}`;
+        if (process.stdout && typeof process.stdout.write === 'function') {
+          process.stdout.write(`${statusLog}\n`);
+        } else {
+          console.log(statusLog);
+        }
       }
       save(`last-response-${Date.now()}.xml`, xml);
       save('last-response.xml', xml);

--- a/src/services/qbxml.status.js
+++ b/src/services/qbxml.status.js
@@ -1,0 +1,58 @@
+'use strict';
+
+function decodeXmlEntities(value) {
+  if (typeof value !== 'string' || value.indexOf('&') === -1) return value;
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function extractAttribute(rawAttributes, attrName) {
+  if (!rawAttributes) return undefined;
+  const doubleQuoted = new RegExp(`${attrName}\\s*=\\s*"([^"]*)"`, 'i').exec(rawAttributes);
+  if (doubleQuoted) return decodeXmlEntities(doubleQuoted[1]);
+  const singleQuoted = new RegExp(`${attrName}\\s*=\\s*'([^']*)'`, 'i').exec(rawAttributes);
+  if (singleQuoted) return decodeXmlEntities(singleQuoted[1]);
+  return undefined;
+}
+
+function normalizeStatusCode(value) {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (/^-?\d+$/.test(trimmed)) {
+    const asNumber = Number(trimmed);
+    if (Number.isSafeInteger(asNumber)) return asNumber;
+  }
+  return trimmed;
+}
+
+function extractStatusSummaries(qbxmlText) {
+  if (typeof qbxmlText !== 'string' || qbxmlText.trim() === '') return [];
+
+  const statuses = [];
+  const regex = /<([A-Za-z0-9]+)Rs\b([^>]*)>/g;
+  let match;
+  while ((match = regex.exec(qbxmlText)) !== null) {
+    const [, responseName, rawAttributes = ''] = match;
+    const statusCode = extractAttribute(rawAttributes, 'statusCode');
+    const statusSeverity = extractAttribute(rawAttributes, 'statusSeverity');
+    const statusMessage = extractAttribute(rawAttributes, 'statusMessage');
+
+    if (statusCode || statusSeverity || statusMessage) {
+      const entry = { response: `${responseName}Rs` };
+      if (statusCode != null) entry.statusCode = normalizeStatusCode(statusCode);
+      if (statusSeverity != null) entry.statusSeverity = statusSeverity;
+      if (statusMessage != null) entry.statusMessage = statusMessage;
+      statuses.push(entry);
+    }
+  }
+
+  return statuses;
+}
+
+module.exports = {
+  extractStatusSummaries,
+};


### PR DESCRIPTION
## Summary
- add a helper to extract status information from QuickBooks QBXML responses
- log status codes and messages when receiveResponseXML is called in both the Express stub and qbwcService

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0c0678604832c8d5f91aff5df1832