### PR TITLE
Ensure ItemInventoryMod fields follow qbXML order

### DIFF
--- a/src/services/qbd.itemMod.js
+++ b/src/services/qbd.itemMod.js
@@ -2,6 +2,38 @@
 
 const { escapeXml, qbxmlEnvelope } = require('./qbd.xmlUtils');
 
+const BARCODE_FIELD_KEYS = new Set(['BarCodeValue', 'BarCodeAllowOverride', 'BarCodeAssignEvenIfUsed']);
+
+const FIELD_SEQUENCE = [
+  'Name',
+  'IsActive',
+  'ParentRef',
+  'ClassRef',
+  'ManufacturerPartNumber',
+  'UnitOfMeasureSetRef',
+  'IsTaxIncluded',
+  'SalesTaxCodeRef',
+  'BarCode',
+  'SalesDesc',
+  'SalesPrice',
+  'IncomeAccountRef',
+  'ApplyIncomeAccountRefToExistingTxns',
+  'PurchaseDesc',
+  'PurchaseCost',
+  'PurchaseTaxCodeRef',
+  'COGSAccountRef',
+  'PrefVendorRef',
+  'AssetAccountRef',
+  'ReorderPoint',
+  'Max',
+  'QuantityOnHand',
+  'InventorySiteRef',
+  'InventorySiteLocationRef',
+  'QuantityOnOrder',
+  'QuantityOnSalesOrder',
+  'ExternalGUID',
+];
+
 function tagIfValue(tag, value) {
   if (value == null) return '';
   const val = typeof value === 'number' ? String(value) : String(value).trim();
@@ -19,24 +51,21 @@ function renderNested(tag, value) {
   return `<${tag}>${inner}</${tag}>`;
 }
 
-function renderField(key, value, allFields) {
-  if (key === 'BarCodeValue') {
-    const barCodeValue = tagIfValue('BarCodeValue', value);
-    if (!barCodeValue) return '';
-    const allowOverride = tagIfValue('AllowOverride', allFields.BarCodeAllowOverride);
-    const assignEvenIfUsed = tagIfValue('AssignEvenIfUsed', allFields.BarCodeAssignEvenIfUsed);
-    return `<BarCode>${allowOverride}${assignEvenIfUsed}${barCodeValue}</BarCode>`;
-  }
-
-  if (key === 'BarCodeAllowOverride' || key === 'BarCodeAssignEvenIfUsed') {
-    return '';
-  }
-
+function renderField(key, value) {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
     return renderNested(key, value);
   }
 
   return tagIfValue(key, value);
+}
+
+function renderBarCodeAggregate(fields) {
+  const barCodeValue = tagIfValue('BarCodeValue', fields.BarCodeValue);
+  if (!barCodeValue) return '';
+
+  const allowOverride = tagIfValue('AllowOverride', fields.BarCodeAllowOverride);
+  const assignEvenIfUsed = tagIfValue('AssignEvenIfUsed', fields.BarCodeAssignEvenIfUsed);
+  return `<BarCode>${allowOverride}${assignEvenIfUsed}${barCodeValue}</BarCode>`;
 }
 
 function buildItemInventoryModXML({ ListID, EditSequence, fields = {} }, qbxmlVer = process.env.QBXML_VER || '16.0') {
@@ -48,10 +77,35 @@ function buildItemInventoryModXML({ ListID, EditSequence, fields = {} }, qbxmlVe
   delete payloadFields.ListID;
   delete payloadFields.EditSequence;
 
-  const lines = Object.entries(payloadFields)
-    .map(([key, value]) => renderField(key, value, payloadFields))
-    .filter(Boolean)
-    .join('');
+  const segments = [];
+  const processed = new Set();
+
+  for (const key of FIELD_SEQUENCE) {
+    if (key === 'BarCode') {
+      const aggregate = renderBarCodeAggregate(payloadFields);
+      if (aggregate) segments.push(aggregate);
+      processed.add('BarCode');
+      BARCODE_FIELD_KEYS.forEach((barcodeKey) => processed.add(barcodeKey));
+      continue;
+    }
+
+    if (processed.has(key)) continue;
+    if (!(key in payloadFields)) continue;
+
+    const rendered = renderField(key, payloadFields[key]);
+    if (rendered) segments.push(rendered);
+    processed.add(key);
+  }
+
+  for (const [key, value] of Object.entries(payloadFields)) {
+    if (processed.has(key)) continue;
+
+    const rendered = renderField(key, value);
+    if (rendered) segments.push(rendered);
+    processed.add(key);
+  }
+
+  const lines = segments.join('');
 
   if (!lines) return '';
 


### PR DESCRIPTION
## Summary
- order ItemInventoryMod fields according to the qbXML sequence so SalesDesc/SalesPrice follow the BarCode aggregate
- render the BarCode aggregate explicitly and append any unrecognized fields afterward to retain flexibility

## Testing
- node - <<'NODE'
const { buildItemInventoryModXML } = require('./src/services/qbd.itemMod');

const qbxml = buildItemInventoryModXML({
  ListID: '80000009-12345',
  EditSequence: '123',
  fields: {
    SalesPrice: 12.34,
    SalesDesc: 'Test desc',
    BarCodeValue: '123456789012',
    BarCodeAllowOverride: true,
    BarCodeAssignEvenIfUsed: false,
    PurchaseCost: 5,
    SomeCustomField: 'custom',
  }
});

console.log(qbxml);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d0d78fd6ac832cb867ff02281b42e4