### PR TITLE
Align inventory snapshot storage with shared log directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,17 +19,17 @@ const {
   setCurrentJob,
   getCurrentJob,
   clearCurrentJob,
+  LOG_DIR,
+  ensureDir: ensureLogDir,
 } = require('./services/jobQueue');
 require('dotenv').config();
 
 /* ===== Config ===== */
 const PORT      = process.env.PORT || 8080;             // En Azure Linux escucha 8080
 const BASE_PATH = process.env.BASE_PATH || '/qbwc';
-const LOG_DIR   = process.env.LOG_DIR || '/tmp';
 const LAST_ERROR_FILE = 'last-error.txt';
 const TNS       = 'http://developer.intuit.com/';
 
-function ensureLogDir(){ try{ fs.mkdirSync(LOG_DIR,{recursive:true}); }catch{} }
 function fp(n){ return path.join(LOG_DIR,n); }
 function readText(f){ return fs.existsSync(f) ? fs.readFileSync(f,'utf8') : null; }
 function save(name, txt){ ensureLogDir(); fs.writeFileSync(fp(name), txt??'', 'utf8'); }
@@ -79,7 +79,7 @@ function envelope(body){
          `<soap:Body>${body}</soap:Body></soap:Envelope>`;
 }
 
-/* ===== Cola de trabajos (persistida en /tmp) ===== */
+/* ===== Cola de trabajos (persistida en LOG_DIR) ===== */
 async function enqueue(job){
   return enqueueJob(job);
 }

--- a/src/services/shopify.sync.js
+++ b/src/services/shopify.sync.js
@@ -2,14 +2,14 @@
 const fs = require('fs');
 const path = require('path');
 const { findVariantBySKU, setInventoryLevel } = require('./shopify.client');
+const { LOG_DIR, ensureDir: ensureLogDir } = require('./jobQueue');
 // Polyfill: usa fetch nativo (Node>=18) o node-fetch si hace falta
 const _fetch = (typeof fetch === 'function')
   ? fetch
   : (...args) => import('node-fetch').then(m => m.default(...args));
 
-const TMP_DIR = '/tmp';
-const SNAP_PATH = path.join(TMP_DIR, 'last-inventory.json');
-const LAST_PUSH_PATH = path.join(TMP_DIR, 'shopify-last-pushed.json');
+const SNAP_PATH = path.join(LOG_DIR, 'last-inventory.json');
+const LAST_PUSH_PATH = path.join(LOG_DIR, 'shopify-last-pushed.json');
 
 // --- Debug helpers ---
 const DEBUG = /^(1|true|yes)$/i.test(process.env.SHOPIFY_SYNC_DEBUG || '');
@@ -95,6 +95,7 @@ function loadSnapshot() {
 }
 function saveLastPush(plan) {
   const payload = { pushedAt: new Date().toISOString(), ...plan };
+  ensureLogDir();
   fs.writeFileSync(LAST_PUSH_PATH, JSON.stringify(payload, null, 2), 'utf8');
   return payload;
 }


### PR DESCRIPTION
## Summary
- use the shared `LOG_DIR` export in the sync, debug inventory route and QBWC service so all inventory snapshots resolve to the same base path
- ensure the log directory exists before persisting snapshots or Shopify push metadata
- wire the main server to reuse the queue's `LOG_DIR`/`ensureDir` helpers and refresh related comments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d322e56038832cb51f92dc305ff9b2