### PR TITLE
Add Shopify sync lock and prune processed snapshot items

### DIFF
--- a/src/routes/sync.qbd-to-shopify.js
+++ b/src/routes/sync.qbd-to-shopify.js
@@ -1,17 +1,37 @@
 // src/routes/sync.qbd-to-shopify.js
 const express = require('express');
-const { dryRun, apply } = require('../services/shopify.sync');
+const { dryRun, apply, LOCK_ERROR_CODE } = require('../services/shopify.sync');
 
 const router = express.Router();
 
 router.get('/qbd-to-shopify/dry-run', async (req, res) => {
-  try { const r = await dryRun(req.query.limit ? Number(req.query.limit) : undefined); res.json(r); }
-  catch (e) { res.status(500).json({ error: String(e.message || e) }); }
+  try {
+    const r = await dryRun(req.query.limit ? Number(req.query.limit) : undefined);
+    res.json(r);
+  } catch (e) {
+    if (e && e.code === LOCK_ERROR_CODE) {
+      const payload = { error: e.message, code: e.code };
+      if (e.lock) payload.lock = e.lock;
+      res.status(409).json(payload);
+    } else {
+      res.status(500).json({ error: String(e.message || e) });
+    }
+  }
 });
 
 router.post('/qbd-to-shopify/apply', async (req, res) => {
-  try { const r = await apply(req.query.limit ? Number(req.query.limit) : undefined); res.json(r); }
-  catch (e) { res.status(500).json({ error: String(e.message || e) }); }
+  try {
+    const r = await apply(req.query.limit ? Number(req.query.limit) : undefined);
+    res.json(r);
+  } catch (e) {
+    if (e && e.code === LOCK_ERROR_CODE) {
+      const payload = { error: e.message, code: e.code };
+      if (e.lock) payload.lock = e.lock;
+      res.status(409).json(payload);
+    } else {
+      res.status(500).json({ error: String(e.message || e) });
+    }
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add a filesystem-based lock to the Shopify sync service to prevent overlapping dry-run/apply cycles and expose lock state to routes and the auto-run trigger
- enhance apply() to keep source metadata, prune successfully processed items from the snapshot, and persist lock-aware responses for API callers
- adjust API routes and auto-run workflow to honor the new lock semantics and return friendly 409 responses when a sync is already running

## Testing
- node --check src/services/shopify.sync.js
- node --check src/index.js
- node --check src/routes/sync.qbd-to-shopify.js

------
https://chatgpt.com/codex/tasks/task_e_68d38638cebc832c9d810cb1e8333db5