### PR TITLE
Prevent pruning unmatched SKUs from snapshot

### DIFF
--- a/src/services/shopify.sync.js
+++ b/src/services/shopify.sync.js
@@ -395,10 +395,12 @@ async function apply(limit) {
     const successIndices = new Set();
     const successListIds = new Set();
     for (const r of results) {
-      if (r && r.ok) {
-        if (Number.isInteger(r.snapshotIndex)) successIndices.add(r.snapshotIndex);
-        if (r.listId != null) successListIds.add(String(r.listId));
-      }
+      if (!r || !r.ok) continue;
+      if (r.action !== 'SET_AVAILABLE') continue;
+      if (!r.inventory_item_id) continue;
+
+      if (Number.isInteger(r.snapshotIndex)) successIndices.add(r.snapshotIndex);
+      if (r.listId != null) successListIds.add(String(r.listId));
     }
 
     const pruned = pruneSnapshot(successIndices, successListIds);


### PR DESCRIPTION
## Summary
- require successful quantity syncs with an inventory item before pruning snapshot entries
- ensure unmatched SKUs remain in the snapshot for future Shopify availability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca6383e78832cbec6eb9d63e04b4c