### PR TITLE
Include Shopify purchase price metadata in invoice lines

### DIFF
--- a/src/services/qbd.invoice.js
+++ b/src/services/qbd.invoice.js
@@ -44,6 +44,16 @@ function lineXml(line = {}) {
       ? line.ShopifyPrice
       : line.shopifyPrice != null
       ? line.shopifyPrice
+      : line.PurchasePrice != null
+      ? line.PurchasePrice
+      : line.purchasePrice != null
+      ? line.purchasePrice
+      : line.purchase_price != null
+      ? line.purchase_price
+      : line.Price != null
+      ? line.Price
+      : line.price != null
+      ? line.price
       : null;
   const amount = line.Amount != null ? line.Amount : line.amount;
   const resolvedRate = rate != null ? rate : shopifyPrice;
@@ -51,6 +61,9 @@ function lineXml(line = {}) {
   const amountStr = amount != null ? formatMoney(amount) : null;
   if (rateStr != null) parts.push(`<Rate>${rateStr}</Rate>`);
   if (amountStr != null && rateStr == null) parts.push(`<Amount>${amountStr}</Amount>`);
+
+  const purchasePriceStr = shopifyPrice != null ? formatMoney(shopifyPrice) : null;
+  if (purchasePriceStr != null) parts.push(`<Other1>${purchasePriceStr}</Other1>`);
 
   if (line.ServiceDate || line.serviceDate) {
     const xml = optionalDate('ServiceDate', line.ServiceDate || line.serviceDate);


### PR DESCRIPTION
## Summary
- expand the invoice line builder to accept Shopify purchase prices provided under several common property names
- emit the Shopify purchase price in the generated QBXML, keeping it available as both the line rate and an Other1 attribute

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd950ce17c832c992f3cef85abcfb9