### PR TITLE
Align Shopify invoice export with QBD expectations

### DIFF
--- a/src/services/qbd.invoice.js
+++ b/src/services/qbd.invoice.js
@@ -112,7 +112,6 @@ function buildInvoiceXML(payload = {}, qbxmlVer = process.env.QBXML_VER || '16.0
         ${refXml('ARAccountRef', payload.arAccount || payload.ARAccountRef)}
         ${refXml('TemplateRef', payload.template || payload.TemplateRef)}
         ${optionalDate('TxnDate', payload.txnDate || payload.TxnDate)}
-        ${optionalTag('RefNumber', payload.refNumber || payload.RefNumber)}
         ${refXml('TermsRef', payload.terms || payload.TermsRef)}
         ${optionalDate('DueDate', payload.dueDate || payload.DueDate)}
         ${optionalTag('PONumber', payload.poNumber || payload.PONumber)}


### PR DESCRIPTION
## Summary
- default Shopify shipping lines to the "SHIPPING WITH GUARANTEE" item with the expected description and tax code
- capture the Shopify order number as the invoice memo so QBD shows the external reference
- stop including RefNumber in InvoiceAdd requests so QuickBooks Desktop assigns the document number

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dead2da6cc832cbee9ef31e7afeb4c