### PR TITLE
Add QBXML invoice generation for Shopify orders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const { buildInventoryQueryXML } = require('./services/inventory');
 const { parseInventoryFromQBXML } = require('./services/inventoryParser');
 const { buildInventoryAdjustmentXML } = require('./services/qbd.adjustment');
 const { buildSalesReceiptXML } = require('./services/qbd.salesReceipt');
+const { buildInvoiceXML } = require('./services/qbd.invoice');
 const { buildCreditMemoXML } = require('./services/qbd.creditMemo');
 const { buildItemInventoryModXML } = require('./services/qbd.itemMod');
 const {
@@ -162,6 +163,11 @@ function qbxmlFor(job) {
   if (job.type === 'salesReceiptAdd') {
     const ver = job.qbxmlVer || process.env.QBXML_VER || '16.0';
     return buildSalesReceiptXML(job.payload || job, ver);
+  }
+
+  if (job.type === 'invoiceAdd') {
+    const ver = job.qbxmlVer || process.env.QBXML_VER || '16.0';
+    return buildInvoiceXML(job.payload || job, ver);
   }
 
   if (job.type === 'creditMemoAdd') {

--- a/src/routes/shopify.webhooks.js
+++ b/src/routes/shopify.webhooks.js
@@ -271,6 +271,26 @@ router.post('/webhooks/orders/paid', rawJson, async (req, res) => {
     const shippingLines = buildShippingLines(payload);
     const discountLine = buildDiscountLine(payload);
 
+    const productTaxCodeRef = envRef('QBD_SHOPIFY_PRODUCT_TAX_CODE', 'TAX');
+    const shippingTaxCodeRef = envRef('QBD_SHOPIFY_SHIPPING_TAX_CODE', 'NON');
+
+    if (productTaxCodeRef) {
+      matched.forEach((line) => {
+        if (!line.SalesTaxCodeRef) line.SalesTaxCodeRef = { ...productTaxCodeRef };
+      });
+    }
+
+    if (shippingTaxCodeRef) {
+      shippingLines.forEach((line) => {
+        line.SalesTaxCodeRef = { ...shippingTaxCodeRef };
+      });
+    }
+
+    if (discountLine && !discountLine.SalesTaxCodeRef) {
+      const discountTaxCode = productTaxCodeRef || shippingTaxCodeRef;
+      if (discountTaxCode) discountLine.SalesTaxCodeRef = { ...discountTaxCode };
+    }
+
     const allLines = [...matched, ...shippingLines];
     if (discountLine) allLines.push(discountLine);
 
@@ -278,25 +298,32 @@ router.post('/webhooks/orders/paid', rawJson, async (req, res) => {
       return res.status(200).json({ ok: true, queued: false, notFound });
     }
 
-    const customerSource = payload?.order ? payload.order : { ...payload, id: payload?.order_id || payload?.id };
+    const customerRef = envRef('QBD_SHOPIFY_INVOICE_CUSTOMER', 'ONLINE SALES');
+    const itemSalesTaxRef = envRef('QBD_SHOPIFY_SALES_TAX_ITEM', 'FL TAX 7%');
+    const customerSource =
+      payload?.order ? payload.order : { ...payload, id: payload?.order_id || payload?.id };
+    const shopifyOrderId = payload?.id ?? payload?.order_id ?? null;
+    const shopifyOrderNumber = payload?.order_number ?? payload?.name ?? null;
     const jobPayload = {
-      customer: buildCustomerRef(customerSource),
+      customer: customerRef ? { ...customerRef } : buildCustomerRef(customerSource),
+      itemSalesTaxRef: itemSalesTaxRef ? { ...itemSalesTaxRef } : undefined,
+      shopifyOrderId,
+      shopifyOrderNumber,
+      requestId: shopifyOrderId != null ? `INV-${shopifyOrderId}` : undefined,
+      poNumber: shopifyOrderNumber || undefined,
+      memo:
+        shopifyOrderNumber || shopifyOrderId
+          ? `Pedido Shopify #${shopifyOrderNumber || shopifyOrderId}`
+          : undefined,
       txnDate: toQBDate(payload?.processed_at || payload?.created_at),
-      refNumber: buildRefNumber(payload?.order_number ?? payload?.name, 'SO', payload?.id),
-      memo: `Shopify order ${payload?.name || payload?.order_number || payload?.id}`,
+      refNumber: buildRefNumber(shopifyOrderNumber, 'SO', shopifyOrderId),
       billAddress: mapAddress(payload?.billing_address),
       shipAddress: mapAddress(payload?.shipping_address),
       lines: allLines,
     };
 
-    const paymentMethodRef = envRef('QBD_SHOPIFY_PAYMENT_METHOD');
-    if (paymentMethodRef) jobPayload.paymentMethod = paymentMethodRef;
-
-    const depositAccountRef = envRef('QBD_SHOPIFY_DEPOSIT_ACCOUNT');
-    if (depositAccountRef) jobPayload.depositToAccount = depositAccountRef;
-
     await enqueueJob({
-      type: 'salesReceiptAdd',
+      type: 'invoiceAdd',
       source: 'shopify-order',
       createdAt: new Date().toISOString(),
       payload: jobPayload,

--- a/src/services/qbd.invoice.js
+++ b/src/services/qbd.invoice.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const {
+  escapeXml,
+  qbxmlEnvelope,
+  itemRefXml,
+  refXml,
+  addressXml,
+  formatMoney,
+} = require('./qbd.xmlUtils');
+
+function optionalTag(tag, value) {
+  if (value == null) return '';
+  const val = typeof value === 'number' ? String(value) : String(value).trim();
+  if (!val) return '';
+  return `<${tag}>${escapeXml(val)}</${tag}>`;
+}
+
+function resolveRefXml(tag, value) {
+  if (!value) return '';
+  if (typeof value === 'object') return refXml(tag, value);
+  const trimmed = String(value).trim();
+  if (!trimmed) return '';
+  return `<${tag}><FullName>${escapeXml(trimmed)}</FullName></${tag}>`;
+}
+
+function customerRefXml(payload = {}) {
+  if (payload.customer) return refXml('CustomerRef', payload.customer);
+  const name = payload.customerFullName || payload.customerName || 'ONLINE SALES';
+  if (!name) return '';
+  return `<CustomerRef><FullName>${escapeXml(name)}</FullName></CustomerRef>`;
+}
+
+function itemSalesTaxRefXml(payload = {}) {
+  if (payload.itemSalesTaxRef) return refXml('ItemSalesTaxRef', payload.itemSalesTaxRef);
+  const fullName = payload.itemSalesTaxName || 'FL TAX 7%';
+  if (!fullName) return '';
+  return `<ItemSalesTaxRef><FullName>${escapeXml(fullName)}</FullName></ItemSalesTaxRef>`;
+}
+
+function lineXml(line = {}) {
+  if (!line) return '';
+  const parts = [];
+  const itemXml = itemRefXml(line.ItemRef || line.itemRef || line.item || {});
+  if (itemXml) parts.push(itemXml);
+  if (line.Desc || line.desc) parts.push(`<Desc>${escapeXml(line.Desc || line.desc)}</Desc>`);
+  if (line.Quantity != null) parts.push(`<Quantity>${escapeXml(line.Quantity)}</Quantity>`);
+  const rate = line.Rate != null ? line.Rate : line.rate;
+  const amount = line.Amount != null ? line.Amount : line.amount;
+  const rateStr = rate != null ? formatMoney(rate) : null;
+  const amountStr = amount != null ? formatMoney(amount) : null;
+  if (rateStr != null) parts.push(`<Rate>${rateStr}</Rate>`);
+  if (amountStr != null && rateStr == null) parts.push(`<Amount>${amountStr}</Amount>`);
+  if (line.SalesTaxCodeRef) parts.push(refXml('SalesTaxCodeRef', line.SalesTaxCodeRef));
+  return parts.length ? `<InvoiceLineAdd>${parts.join('')}</InvoiceLineAdd>` : '';
+}
+
+function buildInvoiceXML(payload = {}, qbxmlVer = process.env.QBXML_VER || '16.0') {
+  const lines = Array.isArray(payload.lines) ? payload.lines.map(lineXml).filter(Boolean) : [];
+  if (!lines.length) return '';
+
+  const requestIdRaw =
+    payload.requestId ||
+    payload.RequestID ||
+    (payload.shopifyOrderId != null ? `INV-${payload.shopifyOrderId}` : null) ||
+    'invoice-1';
+  const requestId = escapeXml(requestIdRaw);
+
+  const poNumber =
+    payload.poNumber ||
+    payload.PONumber ||
+    payload.shopifyOrderNumber ||
+    payload.shopifyOrderName ||
+    null;
+  const memo =
+    payload.memo ||
+    payload.Memo ||
+    (payload.shopifyOrderNumber
+      ? `Pedido Shopify #${payload.shopifyOrderNumber}`
+      : payload.shopifyOrderName
+      ? `Pedido Shopify #${payload.shopifyOrderName}`
+      : null);
+
+  const billAddress = addressXml('BillAddress', payload.billAddress);
+  const shipAddress = addressXml('ShipAddress', payload.shipAddress);
+  const customerRef = customerRefXml(payload);
+  const itemSalesTaxRef = itemSalesTaxRefXml(payload);
+
+  const invoiceParts = [
+    customerRef,
+    resolveRefXml('ClassRef', payload.ClassRef),
+    resolveRefXml('ARAccountRef', payload.ARAccountRef),
+    resolveRefXml('TemplateRef', payload.TemplateRef),
+    optionalTag('TxnDate', payload.txnDate || payload.TxnDate),
+    optionalTag('RefNumber', payload.refNumber || payload.RefNumber),
+    optionalTag('PONumber', poNumber),
+    optionalTag('Memo', memo),
+    resolveRefXml('TermsRef', payload.TermsRef),
+    resolveRefXml('SalesRepRef', payload.SalesRepRef),
+    itemSalesTaxRef,
+    billAddress,
+    shipAddress,
+    ...lines,
+  ].filter(Boolean);
+
+  const body = `
+<QBXML>
+  <QBXMLMsgsRq onError="stopOnError">
+    <InvoiceAddRq requestID="${requestId}">
+      <InvoiceAdd>
+        ${invoiceParts.join('\n        ')}
+      </InvoiceAdd>
+    </InvoiceAddRq>
+  </QBXMLMsgsRq>
+</QBXML>`;
+
+  return qbxmlEnvelope(body, qbxmlVer);
+}
+
+module.exports = { buildInvoiceXML };


### PR DESCRIPTION
## Summary
- add a QBXML invoice builder that mirrors the Shopify order pricing, taxes, and references
- queue `invoiceAdd` jobs from the Shopify paid webhook with ONLINE SALES, FL TAX 7%, and tax-code overrides
- allow the job processor to render the new invoice payloads into QBXML

## Testing
- node - <<'EOF'
const { buildInvoiceXML } = require('./src/services/qbd.invoice');
const xml = buildInvoiceXML({
  shopifyOrderId: 999,
  shopifyOrderNumber: '10523',
  lines: [
    {
      ItemRef: { FullName: 'PRUEBA-INVOICE' },
      Desc: 'PRUEBA-INVOICE',
      Quantity: 2,
      Rate: 8,
      SalesTaxCodeRef: { FullName: 'TAX' },
    },
    {
      ItemRef: { FullName: 'SHIPPING WITH GUARANTEE' },
      Desc: 'CHARGE TO BE APPLIED TO ANY SHIP ITEM',
      Quantity: 1,
      Rate: 7.5,
      SalesTaxCodeRef: { FullName: 'NON' },
    },
  ],
  itemSalesTaxRef: { FullName: 'FL TAX 7%' },
  customer: { FullName: 'ONLINE SALES' },
});
console.log(xml);
EOF

------
https://chatgpt.com/codex/tasks/task_e_68dec5035b90832c921484bbc6d07a55