### PR TITLE
Adjust invoice XML field ordering

### DIFF
--- a/src/services/qbd.invoice.js
+++ b/src/services/qbd.invoice.js
@@ -93,13 +93,13 @@ function buildInvoiceXML(payload = {}, qbxmlVer = process.env.QBXML_VER || '16.0
     resolveRefXml('TemplateRef', payload.TemplateRef),
     optionalTag('TxnDate', payload.txnDate || payload.TxnDate),
     optionalTag('RefNumber', payload.refNumber || payload.RefNumber),
-    optionalTag('PONumber', poNumber),
-    optionalTag('Memo', memo),
     resolveRefXml('TermsRef', payload.TermsRef),
     resolveRefXml('SalesRepRef', payload.SalesRepRef),
-    itemSalesTaxRef,
     billAddress,
     shipAddress,
+    itemSalesTaxRef,
+    optionalTag('PONumber', poNumber),
+    optionalTag('Memo', memo),
     ...lines,
   ].filter(Boolean);
 


### PR DESCRIPTION
## Summary
- reorder the invoice XML assembly so address and tax references precede the PO number and memo fields

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dedfde3bb0832c8ebbfa665f295486