### PR TITLE
Add initial inventory sweep with unmatched reporting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -628,6 +628,19 @@ app.post(BASE_PATH, (req,res)=>{
               end: end.toISOString(),
             });
 
+          try {
+            const { runInitialSweepIfNeeded, isInitialSweepEnabled } = require('./services/shopify.sync');
+            if (isInitialSweepEnabled()) {
+              setImmediate(() =>
+                runInitialSweepIfNeeded().catch((err) => {
+                  console.error('Initial sweep auto-run error:', err);
+                })
+              );
+            }
+          } catch (err) {
+            console.error('Initial sweep trigger setup failed:', err);
+          }
+
           // --- Auto push a Shopify (después de persistir el snapshot) ---
           try {
             const m = resp.match(/<ItemInventoryQueryRs[^>]*statusCode="(\d+)"/i);

--- a/src/routes/sync.qbd-to-shopify.js
+++ b/src/routes/sync.qbd-to-shopify.js
@@ -1,6 +1,15 @@
 // src/routes/sync.qbd-to-shopify.js
 const express = require('express');
-const { dryRun, apply, LOCK_ERROR_CODE } = require('../services/shopify.sync');
+const {
+  dryRun,
+  apply,
+  LOCK_ERROR_CODE,
+  runInitialSweepIfNeeded,
+  readInitialSweepUnmatchedQbd,
+  readInitialSweepUnmatchedShopify,
+  readInitialSweepStatus,
+  isInitialSweepEnabled,
+} = require('../services/shopify.sync');
 
 const router = express.Router();
 
@@ -32,6 +41,48 @@ router.post('/qbd-to-shopify/apply', async (req, res) => {
       res.status(500).json({ error: String(e.message || e) });
     }
   }
+});
+
+router.get('/initial/status', (_req, res) => {
+  const status = readInitialSweepStatus();
+  res.json({
+    enabled: isInitialSweepEnabled(),
+    status: status || null,
+  });
+});
+
+router.post('/initial/run', async (_req, res) => {
+  if (!isInitialSweepEnabled()) {
+    res.status(409).json({
+      error: 'Initial sweep is disabled by environment configuration.',
+    });
+    return;
+  }
+
+  try {
+    const result = await runInitialSweepIfNeeded();
+    res.json({ ok: true, result: result || null });
+  } catch (err) {
+    res.status(500).json({ error: String(err?.message || err) });
+  }
+});
+
+router.get('/initial/unmatched/qbd', (req, res) => {
+  const data = readInitialSweepUnmatchedQbd();
+  if (!data) {
+    res.status(404).json({ error: 'Initial sweep QBD unmatched data not available.' });
+    return;
+  }
+  res.json(data);
+});
+
+router.get('/initial/unmatched/shopify', (req, res) => {
+  const data = readInitialSweepUnmatchedShopify();
+  if (!data) {
+    res.status(404).json({ error: 'Initial sweep Shopify unmatched data not available.' });
+    return;
+  }
+  res.json(data);
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- extend the Shopify sync service to support an initial sweep that updates all matched SKUs, records unmatched products, and is gated by the `INITIAL_SWEEP_ENABLED` flag
- expose `/sync/initial/*` endpoints to trigger the sweep and retrieve unmatched products from QuickBooks and Shopify for auditing
- automatically trigger the initial sweep after saving a new inventory snapshot when the feature flag is enabled

## Testing
- `node -e "require('./src/services/shopify.sync')"`


------
https://chatgpt.com/codex/tasks/task_e_68e01826acbc832cb3ed2e73f335316e