### PR TITLE
Avoid keepalive pings while app is receiving real traffic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ const morgan  = require('morgan');
 const path    = require('path');
 const fs      = require('fs');
 const crypto  = require('crypto');
+const http    = require('http');
+const https   = require('https');
 const { buildInventoryQueryXML } = require('./services/inventory');
 const { parseInventoryFromQBXML } = require('./services/inventoryParser');
 const { buildInventoryAdjustmentXML } = require('./services/qbd.adjustment');
@@ -38,6 +40,70 @@ const LAST_RESPONSE_MAX_AGE_MS = LAST_RESPONSE_MAX_AGE_HOURS > 0
   ? LAST_RESPONSE_MAX_AGE_HOURS * 60 * 60 * 1000
   : 0;
 const LAST_RESPONSE_PATTERN = /^last-response-\d+\.xml$/;
+
+const runtimeState = {
+  lastExternalRequestAt: 0,
+};
+
+function toPositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function startPeriodicHealthPing(state = runtimeState) {
+  const enabled = /^(1|true|yes)$/i.test(String(process.env.HEALTHZ_PING_ENABLED || '').trim());
+  if (!enabled) return;
+
+  const intervalMs = toPositiveInteger(process.env.HEALTHZ_PING_INTERVAL_MS, 5 * 60 * 1000);
+  const timeoutMs = toPositiveInteger(process.env.HEALTHZ_PING_TIMEOUT_MS, 10 * 1000);
+  const explicitUrl = String(process.env.HEALTHZ_PING_URL || '').trim();
+  const derivedUrl = process.env.WEBSITE_HOSTNAME
+    ? `https://${process.env.WEBSITE_HOSTNAME}/healthz`
+    : `http://127.0.0.1:${PORT}/healthz`;
+  const targetUrl = explicitUrl || derivedUrl;
+
+  let parsed;
+  try {
+    parsed = new URL(targetUrl);
+  } catch (err) {
+    console.warn('[healthz-ping] invalid HEALTHZ_PING_URL, skipping periodic ping:', targetUrl);
+    return;
+  }
+
+  const client = parsed.protocol === 'https:' ? https : http;
+  const requestOptions = {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: parsed.port || undefined,
+    path: `${parsed.pathname}${parsed.search}`,
+    method: 'GET',
+    timeout: timeoutMs,
+    headers: { 'user-agent': 'qbd-shopify-healthz-ping/1.0' },
+  };
+
+  const pingOnce = () => {
+    const idleMs = Date.now() - Number(state?.lastExternalRequestAt || 0);
+    if (idleMs > 0 && idleMs < intervalMs) {
+      return;
+    }
+
+    const req = client.request(requestOptions, (res) => {
+      res.resume();
+      if (res.statusCode && res.statusCode >= 400) {
+        console.warn('[healthz-ping] non-success status:', res.statusCode);
+      }
+    });
+
+    req.on('timeout', () => req.destroy(new Error('timeout')));
+    req.on('error', (err) => console.warn('[healthz-ping] failed:', err?.message || err));
+    req.end();
+  };
+
+  console.log(`[healthz-ping] enabled; target=${targetUrl}; intervalMs=${intervalMs}; timeoutMs=${timeoutMs}`);
+  pingOnce();
+  setInterval(pingOnce, intervalMs);
+}
 
 function pruneLastResponses() {
   try {
@@ -364,6 +430,13 @@ function filterInventoryForToday(items, now = new Date()){
 /* ===== App ===== */
 const app = express();
 app.use(morgan(process.env.LOG_LEVEL || 'dev'));
+
+app.use((req, _res, next) => {
+  if (req.path !== '/healthz') {
+    runtimeState.lastExternalRequestAt = Date.now();
+  }
+  next();
+});
 
 app.use('/debug', require('./routes/debug.inventory'));
 app.use('/shopify', require('./routes/shopify.webhooks'));
@@ -769,4 +842,7 @@ app.post(BASE_PATH, (req,res)=>{
 });
 
 /* Start */
-app.listen(PORT, ()=> console.log(`[QBWC] Listening http://localhost:${PORT}${BASE_PATH}`));
+app.listen(PORT, () => {
+  startPeriodicHealthPing();
+  console.log(`[QBWC] Listening http://localhost:${PORT}${BASE_PATH}`);
+});


### PR DESCRIPTION
### Motivation
- Prevent the periodic /healthz keepalive from issuing unnecessary self-pings when the app is already receiving real external traffic, so it doesn't generate extra requests or noise while the service is being actively used.

### Description
- Added an in-memory `runtimeState.lastExternalRequestAt` timestamp and lightweight Express middleware that updates it for every incoming request except `/healthz` to track recent external activity.
- Introduced `toPositiveInteger` helper, required `http`/`https`, and modified `startPeriodicHealthPing(state)` to accept the runtime state and skip a ping when the app was active within the last interval.
- Kept the `/healthz` endpoint behavior unchanged and started the keepalive routine from the server `listen` callback with logging and a configurable target, interval, and timeout.

### Testing
- Ran `node --check src/index.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8272aaa0832c8641fa4ea4f6eb55)