### PR TITLE
Clamp negative QuantityOnHand to 0 before syncing to Shopify

### DIFF
--- a/src/services/shopify.sync.js
+++ b/src/services/shopify.sync.js
@@ -395,7 +395,7 @@ async function buildPlan(limit, options = {}) {
       if (includeNoSku) {
         const op = {
           sku: null,
-          target: Number(it?.QuantityOnHand || 0),
+          target: Math.max(0, Number(it?.QuantityOnHand || 0)),
           inventory_item_id: null,
           action: 'MISSING_SKU',
           snapshotIndex: idx,
@@ -407,7 +407,7 @@ async function buildPlan(limit, options = {}) {
       continue;
     }
 
-    const qty = Number(it.QuantityOnHand || 0);
+    const qty = Math.max(0, Number(it.QuantityOnHand || 0));
     let variant = null;
     try {
       // 1) Búsqueda exacta por SKU con GraphQL (fiable)


### PR DESCRIPTION
QBD allows negative QuantityOnHand (e.g. when more units were invoiced than available stock). The initial sweep and regular apply() were forwarding those negative values directly to Shopify via inventory_levels/set.json, leaving products with negative available inventory.

Math.max(0, ...) is applied in buildPlan() so both code paths (sweep and apply) are covered without duplicating the guard.