### PR TITLE
Preserve job queue when QBD is unavailable during a WC cycle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const { buildItemInventoryModXML } = require('./services/qbd.itemMod');
 const {
   readJobs,
   enqueueJob,
+  withJobsLock,
   peekJob,
   popJob,
   setCurrentJob,
@@ -590,6 +591,22 @@ app.post(BASE_PATH, (req,res)=>{
 
       }
       else if (is('sendRequestXML')) {
+        // If a previous session left a currentJob orphan (sendRequestXML was called but
+        // receiveResponseXML never arrived — e.g. QBD closed mid-session), put that job
+        // back at the front of the queue before picking the next one. Without this, a
+        // successful session after a crash would call clearCurrentJob() and silently
+        // discard the orphaned job forever.
+        const orphanedJob = getCurrentJob();
+        if (orphanedJob) {
+          try {
+            await withJobsLock(async (jobs) => { jobs.unshift(orphanedJob); });
+            console.warn('[qbwc] sendRequestXML: orphaned currentJob re-queued at front', { type: orphanedJob.type, ts: orphanedJob.ts });
+          } catch (reQueueErr) {
+            console.error('[qbwc] sendRequestXML: failed to re-queue orphaned currentJob', reQueueErr);
+          }
+          clearCurrentJob();
+        }
+
         // ¿Hay trabajo en cola?
         let job = peekJob();
         let qbxml = '';
@@ -826,6 +843,24 @@ app.post(BASE_PATH, (req,res)=>{
         const hresult = extract(raw, 'hresult') || '';
         const message = extract(raw, 'message') || '';
         console.error('WC connectionError:', hresult, message);
+
+        // If a job was already popped from the queue and set as currentJob in a
+        // previous sendRequestXML call, QBD closing means receiveResponseXML will
+        // never arrive. Re-queue the orphaned job at the front so it is retried
+        // once QBD is open again, rather than being silently lost.
+        const orphaned = getCurrentJob();
+        if (orphaned) {
+          try {
+            await withJobsLock(async (jobs) => { jobs.unshift(orphaned); });
+            console.warn('[qbwc] connectionError: re-queued orphaned job to front of queue', { type: orphaned.type, ts: orphaned.ts });
+          } catch (reQueueErr) {
+            console.error('[qbwc] connectionError: failed to re-queue orphaned job', reQueueErr);
+          }
+          clearCurrentJob();
+        }
+
+        const errorText = `connectionError ${hresult}: ${message}`;
+        persistLastError(errorText);
         bodyXml = `<connectionErrorResponse xmlns="${TNS}"><connectionErrorResult>DONE</connectionErrorResult></connectionErrorResponse>`;
       }
 


### PR DESCRIPTION
When the Web Connector calls sendRequestXML the job is immediately popped from the queue and stored as currentJob. If QBD is closed at that point, receiveResponseXML never arrives and the job is silently lost — the queue appears empty even though the cycle never completed.

Two guards added to src/index.js:

1. connectionError handler: if a currentJob orphan exists (popped in a previous sendRequestXML but never acknowledged), re-enqueue it at the front of the queue before responding DONE. Also persists the error text so getLastError reports it to the WC.

2. sendRequestXML handler: at the very start, check for an existing currentJob from a prior incomplete session and re-enqueue it before picking the next job. This catches the case where QBD comes back online and a new successful session starts — without this guard, clearCurrentJob() inside receiveResponseXML would silently drop the orphaned job from the previous failed session.

Together these ensure jobs survive any number of failed WC cycles and are only permanently removed from the queue after a fully successful sendRequestXML + receiveResponseXML round trip.